### PR TITLE
Add initial module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.molecule
+.vagrant
+.cache/v/cache
+tests/__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # ansible-python-security
-Ansible Role to install Python security modules.
+Ansible Role to add Python support for TLS SNI.
+
+## Role Variables
+
+- `python_security_ndghttpsclient_version`: Version of `ndg-httpsclient` to install. (Default: `"0.4.*"`)
+- `python_security_pyasn1_version`: Version of `pyasn1` to install. (Default: `"0.2.*"`)
+
+## Testing
+### Requirements
+- Virtualbox 5.1.22+ 
+- Vagrant 1.9.5+
+- Pip 9.0.1+
+- Molecule <= 1.25
+- Ansible 2.3.1+
+
+### Overview
+Tests are done using [molecule](http://molecule.readthedocs.io/). To run the test suite, install molecule and its dependencies and run ` molecule test` from the folder containing molecule.yml. To add additional tests, add a [testinfra](http://testinfra.readthedocs.org/) python script in the [tests](./tests/) directory, or add a function to [test_modules.py](./tests/test_pip.py). Information about available Testinfra modules is available [here](http://testinfra.readthedocs.io/en/latest/modules.html).
+
+### Example 
+```
+# Download molecule, dependencies
+$ pip install molecule
+
+# Change to the top-level project directory, which contains molecule.yml
+$ cd /path/to/ansible-python-security
+
+# Ensure that molecule.yml is present
+$ ls
+CHANGELOG.md 	molecule.yml
+LICENSE 	README.md
+playbook.yml 	tasks
+defaults 	tests
+meta 		roles.yml
+
+# We're in the right directory, so let's run tests!
+$ molecule test
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+python_security_ndghttpsclient_version: "0.4.*"
+python_security_pyasn1_version: "0.2.*"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  author: Taylor Nation
+  description: Ansible Role to add Python support for TLS SNI.
+  company: Azavea, inc.
+  license: Apache
+  min_ansible_version: 2.3.1
+  platforms:
+  - name: Ubuntu
+    versions:
+      - trusty
+  categories:
+  - development
+  - system
+dependencies:
+  - src: azavea.pip
+    version: 1.0.0
+    name: azavea.pip

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,32 @@
+---
+molecule:
+  test:
+    sequence:
+      - destroy
+      - syntax
+      - create
+      - converge
+      - idempotence
+      - verify
+driver:
+  name: vagrant
+vagrant:
+  platforms:
+    - name: ubuntu/trusty64
+      box: trusty64
+      box_url: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 2
+  instances:
+    - name: ansible-python-security
+      ansible_groups:
+        - group1
+verifier:
+  name: testinfra
+dependency:
+  name: galaxy
+  requirements_file: roles.yml

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes cache_valid_time=3600
+
+  roles:
+    - ansible-python-security

--- a/roles.yml
+++ b/roles.yml
@@ -1,0 +1,4 @@
+---
+- role: azavea.pip
+  version: 1.0.0
+  name: azavea.pip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Python TLS SNI dependencies
+  pip: name={{ item.name }}=={{ item.version }} state=present
+  with_items:
+    - { name: ndg-httpsclient, version: "{{ python_security_ndghttpsclient_version }}" }
+    - { name: pyasn1, version: "{{ python_security_pyasn1_version }}" }

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,49 @@
+import pytest
+
+
+@pytest.fixture()
+def AnsibleDefaults(Ansible):
+    """ Load default variables into dictionary.
+    Args:
+        Ansible - Requires the ansible connection backend.
+    """
+    return Ansible("include_vars", "./defaults/main.yml")["ansible_facts"]
+
+
+@pytest.mark.parametrize("pkg_name", [
+    "pyasn1",
+    "ndg-httpsclient",
+])
+def test_modules(AnsibleDefaults, PipPackage, pkg_name):
+    """ Ensure pip modules are installed.
+
+    Args:
+        GetAnsibleDefaults - Get default version of the package
+        PipPackage - Get all installed pip packages
+    """
+    installed_pkgs = PipPackage.get_packages()
+
+    # Get package version from Ansible variables. Naming convention is
+    # <package_name_without_hyphens>_version
+    pkg_version = AnsibleDefaults[
+        "python_security_{}_version".format(pkg_name.replace("-", ""))
+    ].split("*")[0]
+
+    assert pkg_name in installed_pkgs.keys()
+    assert pkg_version in installed_pkgs[pkg_name]["version"]
+
+
+def test_python_ssl(Ansible, File):
+    """ Ensure Python TLS SNI is working
+
+    Args:
+        Ansible -  Use get_url to download a file from a host known to have
+                   TLS SNI enabled.
+        File - Check to see if file downloaded with get_url exists.
+    """
+    get_docker_key = Ansible('get_url',
+                             'url=https://download.docker.com/linux/ubuntu/gpg\
+                             dest=/tmp/docker.key',
+                             check=False)
+    assert get_docker_key["status_code"] == 200
+    assert File("/tmp/docker.key").exists


### PR DESCRIPTION
# Overview

Installs security modules necessary to allow Ansible to interact with webservers that have SNI enabled. Packages are installed with `pip`, and the versions are configurable. Also, add molecule testing setup.

# Testing
- Follow the instructions in the Testing section of the `README`.