### PR TITLE
All SNI dependencies are included in urllib3[secure] package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ Ansible Role to add Python support for TLS SNI.
 
 ## Role Variables
 
-- `python_security_ndghttpsclient_version`: Version of `ndg-httpsclient` to install. (Default: `"0.4.*"`)
-- `python_security_pyasn1_version`: Version of `pyasn1` to install. (Default: `"0.2.*"`)
+- `python_security_urllib3_version`: Version of `urllib3[secure]` to install. (Default: `"1.22.*"`)
 
 ## Testing
 ### Requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-python_security_ndghttpsclient_version: "0.4.*"
-python_security_pyasn1_version: "0.2.*"
+python_security_urllib3_version: "1.22.*"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,3 @@
 ---
 - name: Install Python TLS SNI dependencies
-  pip: name={{ item.name }}=={{ item.version }} state=present
-  with_items:
-    - { name: ndg-httpsclient, version: "{{ python_security_ndghttpsclient_version }}" }
-    - { name: pyasn1, version: "{{ python_security_pyasn1_version }}" }
+  pip: name=urllib3[secure]=={{ python_security_urllib3_version }} state=present

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 
 
 @pytest.fixture()
@@ -10,12 +11,8 @@ def AnsibleDefaults(Ansible):
     return Ansible("include_vars", "./defaults/main.yml")["ansible_facts"]
 
 
-@pytest.mark.parametrize("pkg_name", [
-    "pyasn1",
-    "ndg-httpsclient",
-])
-def test_modules(AnsibleDefaults, PipPackage, pkg_name):
-    """ Ensure pip modules are installed.
+def test_modules(AnsibleDefaults, PipPackage):
+    """ Ensure urllib3 is installed.
 
     Args:
         GetAnsibleDefaults - Get default version of the package
@@ -23,14 +20,12 @@ def test_modules(AnsibleDefaults, PipPackage, pkg_name):
     """
     installed_pkgs = PipPackage.get_packages()
 
-    # Get package version from Ansible variables. Naming convention is
-    # <package_name_without_hyphens>_version
-    pkg_version = AnsibleDefaults[
-        "python_security_{}_version".format(pkg_name.replace("-", ""))
-    ].split("*")[0]
+    # Get package version from Ansible variables.
+    pkg_version = re.match("\d+\.\d+",
+        AnsibleDefaults["python_security_urllib3_version"].split("*")[0]).group(0)  # NOQA E501
 
-    assert pkg_name in installed_pkgs.keys()
-    assert pkg_version in installed_pkgs[pkg_name]["version"]
+    assert 'urllib3' in installed_pkgs.keys()
+    assert pkg_version in installed_pkgs["urllib3"]["version"]
 
 
 def test_python_ssl(Ansible, File):


### PR DESCRIPTION
# Overview

Install `urllib3[secure]`, which contains all of the python dependencies necessary for SSL SNI.
See https://urllib3.readthedocs.io/en/latest/user-guide.html#certificate-verification-in-python-2.

# Testing
- Follow the testing instructions in the `README`. Ensure all tests pass with `molecule==1.25.0`.
- See hunchlab/hunchlab#23
